### PR TITLE
PD-465 - fixes Rails deprecation warnings

### DIFF
--- a/app/decorators/dashboard_decorator.rb
+++ b/app/decorators/dashboard_decorator.rb
@@ -18,7 +18,7 @@ class DashboardDecorator < Draper::Decorator
   end
 
   def name_slug
-    name.downcase.parameterize('-')
+    name.downcase.parameterize()
   end
 
   def notes_to_html

--- a/app/decorators/widget_decorator.rb
+++ b/app/decorators/widget_decorator.rb
@@ -60,7 +60,7 @@ class WidgetDecorator < Draper::Decorator
   end
 
   def name_slug
-    name.downcase.parameterize('-')
+    name.downcase.parameterize()
   end
 
 end


### PR DESCRIPTION
* remove implied '-' from parameterise

I believe that '-' is the implied default for parameterize - http://apidock.com/rails/ActiveSupport/Inflector/parameterize