### PR TITLE
Minor doc/readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Currently WIP.
 
  - ruby-2.3.1
  - Postgres 9.4
+ - Node 6.3.0
 
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ For advice for writing specs check [betterspecs](http://betterspecs.org/).
 Rebasing before merging a PR ensures a clean commit history, please see [Merging vs Rebasing](https://www.atlassian.com/git/tutorials/merging-vs-rebasing/) for more details.
 
 If rebasing often, its a good idea to use `rerere`, see:
-[Fix conflicts only once with git rerere](https://medium.com/@porteneuve/fix-conflicts-only-once-with-git-rerere-7d116b2cec67a)
+[Fix conflicts only once with git rerere](https://medium.com/@porteneuve/fix-conflicts-only-once-with-git-rerere-7d116b2cec67)
 
 If your branch is long-lived (longer than a day on an active codebase), its a good idea to periodically rebase so you are actively tracking changes in master. This makes merge conflicts 1) less likely and 2) smaller and easier to deal with.
 


### PR DESCRIPTION
One minor and one trivial thing I hit when trying to get the dashboard up and running the other night.

Firstly, we should call out the Node dependency prior to referencing npm etc. (TBH I mostly noticed as my laptop had a weird old version that was failing for other reasons). I've just referenced the version used in `package.json` but there might be a better way to do this / more explicitly supported version we should use?

Secondly, I tried to read the Medium link and it 404'd as there was a stray character at the end of the URL.

Apologies for the default `patch-1` branch name also, I used Github's web interface as don't have certs, git, etc., setup on my DTO laptop yet.