### PR TITLE
Idea for datapoints

### DIFF
--- a/app/models/datapoint.rb
+++ b/app/models/datapoint.rb
@@ -1,12 +1,16 @@
 class Datapoint < ApplicationRecord
   belongs_to :dataset
 
-  validates :ts, :presence => true
+  validates :idx, presence: true, uniqueness: { scope: :dataset_id }
 
   validates :value, :numericality => true, :allow_nil => true
 
-  scope :by_time, -> { order(:ts => 'ASC') }
-  scope :by_time_desc, -> { order(:ts => 'DESC') }
+  scope :by_time, -> { order(idx: 'ASC') }
+  scope :by_time_desc, -> { order(idx: 'DESC') }
+
+  def ts
+    dataset.datapoint_ts(self)
+  end
 
   def label
     ts.strftime("%Y-%m")

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -23,6 +23,25 @@ class Dataset < ApplicationRecord
     datapoints.by_time.offset(1).last
   end
 
+  def datapoint_ts(datapoint)
+    case period
+    when 'month'
+      start_ts >> datapoint.idx
+    when 'day'
+      start_ts + datapoint.idx.days
+    when 'week'
+      start_ts + datapoint.idx.weeks
+    end
+  end
+
+  def multiply_period(factor)
+    case period
+    when 'month'
+      factor.months
+    when 'day'
+      factor.days
+    when
+
   def up?
     difference > 0
   end

--- a/db/migrate/20161110022318_make_datapoints_indexed.rb
+++ b/db/migrate/20161110022318_make_datapoints_indexed.rb
@@ -1,0 +1,16 @@
+class MakeDatapointsIndexed < ActiveRecord::Migration[5.0]
+  def change
+    change_table :datasets do |t|
+      t.datetime :start_ts, null: false
+      t.string :period, null: false, default: 'month'
+    end
+
+    change_table :datapoints do |t|
+      t.integer :idx, null: false
+      t.index :idx, unique: true
+
+      t.remove :ts, :datetime, null: false
+      t.remove_index :ts
+    end
+  end
+end

--- a/lib/data/dibp-data.json
+++ b/lib/data/dibp-data.json
@@ -13,13 +13,8 @@
             "units": "%",
             "name": "User satisfaction",
             "note": "",
-            "data": [
-                { "label": "2016-03", "value": 99 },
-                { "label": "2016-04", "value": 95 },
-                { "label": "2016-05", "value": 90 },
-                { "label": "2016-06", "value": 97 },
-                { "label": "2016-07", "value": 96 }
-            ]
+            "start": "2016-03",
+            "data": [99, 95, 90, 97, 96]
         }, {
             "id": "cost-per-transaction",
             "recorded_at": "2016-06-30T01:01:01.111Z",
@@ -33,26 +28,16 @@
             "units": "%",
             "name": "Completion rate",
             "note": "",
-            "data": [
-                { "label": "2016-03", "value": 94 },
-                { "label": "2016-04", "value": 92 },
-                { "label": "2016-05", "value": 97 },
-                { "label": "2016-06", "value": 98 },
-                { "label": "2016-07", "value": 99 }
-            ]
+            "start": "2016-03",
+            "data": [94, 92, 97, 98, 99]
         }, {
             "id": "digital-take-up",
             "recorded_at": "2016-06-30T01:01:01.111Z",
             "units": "%",
             "name": "Digital take-up",
             "note": "",
-            "data": [
-                { "label": "2016-03", "value": 1.9 },
-                { "label": "2016-04", "value": 15 },
-                { "label": "2016-05", "value": 14 },
-                { "label": "2016-06", "value": 23 },
-                { "label": "2016-07", "value": 21.93 }
-            ]
+            "start": "2016-03",
+            "data": [1.9, 15, 14, 23, 21.93]
         },
 
         {
@@ -62,13 +47,8 @@
             "recorded_at": "2016-06-30T01:01:01.111Z",
             "units": "i",
             "note": "note for this dataset",
-            "data": [
-                { "label": "2016-03", "value": 43 },
-                { "label": "2016-04", "value": 48 },
-                { "label": "2016-05", "value": 47 },
-                { "label": "2016-06", "value": 49 },
-                { "label": "2016-07", "value": 50 }
-            ]
+            "start": "2016-03",
+            "data": [43, 48, 47, 49, 50]
         }, {
             "id": "device-type-02",
             "label": "Tablet",
@@ -76,13 +56,8 @@
             "recorded_at": "2016-06-30T01:01:01.111Z",
             "units": "i",
             "note": "note for this dataset",
-            "data": [
-                { "label": "2016-03", "value": 6 },
-                { "label": "2016-04", "value": 6 },
-                { "label": "2016-05", "value": 6 },
-                { "label": "2016-06", "value": 2 },
-                { "label": "2016-07", "value": 3 }
-            ]
+            "start": "2016-03",
+            "data": [6, 6, 6, 2, 3]
         },
 
         {
@@ -92,13 +67,8 @@
             "recorded_at": "2016-06-30T01:01:01.111Z",
             "units": "i",
             "note": "note for this dataset",
-            "data": [
-                { "label": "2016-03", "value": 51 },
-                { "label": "2016-04", "value": 46 },
-                { "label": "2016-05", "value": 47 },
-                { "label": "2016-06", "value": 49 },
-                { "label": "2016-07", "value": 47 }
-            ]
+            "start": "2016-03",
+            "data": [51, 46, 47, 49, 47]
         },
 
         {
@@ -108,13 +78,8 @@
             "recorded_at": "2016-06-30T01:01:01.111Z",
             "units": "i",
             "note": "note for this dataset",
-            "data": [
-                { "label": "2016-03", "value": 16 },
-                { "label": "2016-04", "value": 15 },
-                { "label": "2016-05", "value": 17 },
-                { "label": "2016-06", "value": 16 },
-                { "label": "2016-07", "value": 17 }
-            ]
+            "start": "2016-03",
+            "data": [16, 15, 17, 16, 17]
         },
 
         {
@@ -124,13 +89,8 @@
             "recorded_at": "2016-06-30T01:01:01.111Z",
             "units": "i",
             "note": "note for this dataset",
-            "data": [
-                { "label": "2016-03", "value": 34 },
-                { "label": "2016-04", "value": 41 },
-                { "label": "2016-05", "value": 38 },
-                { "label": "2016-06", "value": 37 },
-                { "label": "2016-07", "value": 37 }
-            ]
+            "start": "2016-03",
+            "data": [34, 41, 38, 37, 37]
         },
 
         {
@@ -140,13 +100,8 @@
             "recorded_at": "2016-06-30T01:01:01.111Z",
             "units": "i",
             "note": "note for this dataset",
-            "data": [
-                { "label": "2016-03", "value": 23 },
-                { "label": "2016-04", "value": 28 },
-                { "label": "2016-05", "value": 28 },
-                { "label": "2016-06", "value": 30 },
-                { "label": "2016-07", "value": 29 }
-            ]
+            "start": "2016-03",
+            "data": [23, 28, 28, 30, 29]
         },
 
         {
@@ -156,13 +111,8 @@
             "recorded_at": "2016-06-30T01:01:01.111Z",
             "units": "i",
             "note": "note for this dataset",
-            "data": [
-                { "label": "2016-03", "value": 16 },
-                { "label": "2016-04", "value": 6 },
-                { "label": "2016-05", "value": 6 },
-                { "label": "2016-06", "value": 6 },
-                { "label": "2016-07", "value": 6 }
-            ]
+            "start": "2016-03",
+            "data": [16, 6, 6, 6, 6]
         },
 
         {
@@ -172,13 +122,8 @@
             "recorded_at": "2016-06-30T01:01:01.111Z",
             "units": "i",
             "note": "note for this dataset",
-            "data": [
-                { "label": "2016-03", "value": 11 },
-                { "label": "2016-04", "value": 10 },
-                { "label": "2016-05", "value": 11 },
-                { "label": "2016-06", "value": 11 },
-                { "label": "2016-07", "value": 11 }
-            ]
+            "start": "2016-03",
+            "data": [11, 10, 11, 11, 11]
         }
 
     ]

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -70,15 +70,15 @@ namespace :import do
           :name => dataset['name'],
           :label => dataset['label'] || dataset['name'],
           :notes => dataset['note'],
-          :units => units)
+          :units => units,
+          :period => dataset['period'] || 'month',
+          :start_ts => DateTime.strptime(data['start'], '%Y-%m'))
 
         datasets[dataset['id']] = dataset_model
 
         if dataset['data']
-
-          dataset['data'].each do |data|
-            ts = DateTime.strptime(data['label'], '%Y-%m')
-            dataset_model.datapoints.create!(:ts => ts, :value => data['value'])
+          dataset['data'].each_with_index do |value, idx|
+            dataset_model.datapoints.create! idx: idx, value: value
           end
         end
       end


### PR DESCRIPTION
Sketch of how datapoints structure would look if we removed timestamp & just indexed them with start timestamp & period on the dataset. 

Advantage to this is that we don't have to worry about complex validation rules and pulling out / pushing in synchronic slices of datapoints across datasets would become trivial. 

Less drastic way could keep `ts` column but make it nullable (i.e. only for datasets that aren't going to be edited via the editor, e.g. external APIs). In this case `ts` getter could be like: 

```
def ts
  self[:ts] || dataset.datapoint_ts(self)
end
```